### PR TITLE
add source mapping

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
     path: path.resolve(__dirname, 'client', 'dist'),
     filename: 'bundle.js'
   },
+  devtool: 'source-map',
   devServer: {
     contentBase: path.resolve(__dirname, 'client', 'dist'),
     open: true,


### PR DESCRIPTION
- Adds a source map to the bundle, this outputs the actual filename in the console when an error occurs instead of it just being shown as part of the bundle.js file. 

A small update. @Gledinburgh @rick-o-H @jonathanAgarcia 