### PR TITLE
Add star rating to overview

### DIFF
--- a/client/src/OverviewComponents/Gallery.jsx
+++ b/client/src/OverviewComponents/Gallery.jsx
@@ -28,7 +28,7 @@ const Gallery = (props) => {
         {mainImagesArr.map((image, index) => {
           return (
             <CarouselItem key={index}>
-              <img className="d-block rounded-sm" src={image} style={{ height: 730, width: 730, objectFit: 'cover' }} alt={props.styles.results[0].name} />
+              <img className="d-block rounded-sm" src={image === null ? 'https://via.placeholder.com/650' : image} style={{ height: 730, width: 730, objectFit: 'cover' }} alt={props.styles.results[0].name} />
             </CarouselItem>
           );
         })}

--- a/client/src/OverviewComponents/ProductDetails.jsx
+++ b/client/src/OverviewComponents/ProductDetails.jsx
@@ -32,8 +32,8 @@ class ProductDetails extends React.Component {
         <Col sm={4} className="my-5">
           {/* pull in the star rating component and link to ratings section below */}
           <div>
-            <div className="my-1">
-              <StarRating ratings={this.props.ratings} />
+            <div className="my-1 flex-row">
+              <StarRating ratings={this.props.ratings} /> <a href="#ratings-and-reviews" style={{color: 'black', fontSize: '.75rem'}}>Read all reviews</a>
             </div>
 
             <p className="my-1" >{this.props.selectedProduct.category}</p>

--- a/client/src/OverviewComponents/ProductDetails.jsx
+++ b/client/src/OverviewComponents/ProductDetails.jsx
@@ -48,7 +48,7 @@ class ProductDetails extends React.Component {
             <Row className="my-2" style={{ maxWidth: 300 }} >
               {/* map through the styles (results arr) and output an image tag for each */}
               {this.props.styles.results.map((style, index) => {
-                return <img key={style.style_id} onClick={this.onThumbnailClick} className="rounded-circle p-1" id={style.style_id} src={style.photos[0].thumbnail_url} style={{ height: 70, width: 70, objectFit: 'cover' }} alt={style.name}/>;
+                return <img key={style.style_id} onClick={this.onThumbnailClick} className="rounded-circle p-1" id={style.style_id} src={style.photos[0].thumbnail_url === null ? 'https://via.placeholder.com/50' : style.photos[0].thumbnail_url} style={{ height: 70, width: 70, objectFit: 'cover' }} alt={style.name}/>;
               })}
             </Row>
           </div>

--- a/client/src/OverviewComponents/ProductDetails.jsx
+++ b/client/src/OverviewComponents/ProductDetails.jsx
@@ -3,6 +3,7 @@ import { Button, Container, Row, Col } from 'react-bootstrap';
 import { Star } from 'react-bootstrap-icons';
 import Variants from './Variants.jsx';
 import Gallery from './Gallery.jsx';
+import StarRating from '../Utilities/StarRating.jsx';
 
 class ProductDetails extends React.Component {
   constructor(props) {
@@ -32,11 +33,7 @@ class ProductDetails extends React.Component {
           {/* pull in the star rating component and link to ratings section below */}
           <div>
             <div className="my-1">
-              <Star />
-              <Star />
-              <Star />
-              <Star />
-              <Star />
+              <StarRating ratings={this.props.ratings} />
             </div>
 
             <p className="my-1" >{this.props.selectedProduct.category}</p>

--- a/client/src/OverviewComponents/ProductOverview.jsx
+++ b/client/src/OverviewComponents/ProductOverview.jsx
@@ -7,7 +7,7 @@ const ProductOverview = (props) => {
 
   return (
     <Container>
-      <ProductDetails selectedProduct={props.selectedProduct} styles={props.styles} />
+      <ProductDetails selectedProduct={props.selectedProduct} styles={props.styles} ratings={props.ratings}/>
       <ProductInfo selectedProduct={props.selectedProduct} />
     </Container>
   );

--- a/client/src/RatingsReviewsComponents/RatingsAndReviews.jsx
+++ b/client/src/RatingsReviewsComponents/RatingsAndReviews.jsx
@@ -5,7 +5,7 @@ import ProductBreakdown from './components/ProductBreakdown.jsx';
 
 const RatingsAndReviews = (props) => {
   return (
-    <div className="container">
+    <div className="container" id="ratings-and-reviews">
       <div className="row">
         <div className="col">
           <p>Ratings & Reviews</p>

--- a/client/src/Utilities/StarRating.jsx
+++ b/client/src/Utilities/StarRating.jsx
@@ -10,7 +10,7 @@ const StarRating = (props) => {
       {props.includeNumber === 1 ? (
         <h1>{(averageRating).slice(0, averageRating)}</h1>
       ) : null}
-      <Col>
+      <Col className='productBreakdownStars'>
         <StarList rating={averageRating} />
       </Col>
     </Row>

--- a/client/src/Utilities/StarRating.jsx
+++ b/client/src/Utilities/StarRating.jsx
@@ -6,16 +6,14 @@ import StarList from './StarList.jsx';
 const StarRating = (props) => {
   const averageRating = CalculateRating(props.ratings);
   return (
-    <Container>
-      <Row>
-        {props.includeNumber === 1 ? (
-          <h1>{(averageRating).slice(0, averageRating)}</h1>
-        ) : null}
-        <Col className='productBreakdownStars'>
-          <StarList rating={averageRating} />
-        </Col>
-      </Row>
-    </Container>
+    <Row>
+      {props.includeNumber === 1 ? (
+        <h1>{(averageRating).slice(0, averageRating)}</h1>
+      ) : null}
+      <Col>
+        <StarList rating={averageRating} />
+      </Col>
+    </Row>
   );
 };
 


### PR DESCRIPTION
@rick-o-H @Gledinburgh  Can you both please take a look at this when you have a chance? 

On the star rating utility component, I removed the outer container that was pushing the stars inward. It looks like an improvement for my comp and Glenn's cards. I don't see any noticeable change with your stars Rick. Please let me know if this will affect your components negatively and I will make a work-around. Thanks! I will add screenshots below. 

Rick, I also had to add an id to the outer div of your RatingAndReviews component for the jump link from my comp, fyi. 

BEFORE: 
![Screen Shot 2020-11-27 at 1 21 56 PM](https://user-images.githubusercontent.com/11343071/100482180-bb9f7180-30b3-11eb-9aa5-b7c56b35570f.png)

AFTER:
![Screen Shot 2020-11-27 at 1 49 40 PM](https://user-images.githubusercontent.com/11343071/100483835-78470200-30b7-11eb-9cc4-6e7dd5f5be1c.png)


AFTER Ratings Comp:
![Screen Shot 2020-11-27 at 1 24 21 PM](https://user-images.githubusercontent.com/11343071/100482232-e8ec1f80-30b3-11eb-9ca8-924a58760bc0.png)
 

